### PR TITLE
fix: prevent orchestrator from invoking meta-commands as skills

### DIFF
--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -79,6 +79,8 @@ These rules define what the ORCHESTRATOR (lead/coordinator) does. Sub-agents are
 5. Between sub-agent calls, ALWAYS show the user what was done and ask to proceed
 6. Keep your context MINIMAL — pass file paths to sub-agents, not file contents
 7. NEVER run phase work inline as the lead. Always delegate.
+8. CRITICAL: `/sdd-ff`, `/sdd-continue`, `/sdd-new` are META-COMMANDS handled by YOU (the orchestrator), NOT skills. NEVER invoke them via the Skill tool. Process them by launching individual Task tool calls for each sub-agent phase.
+9. When a sub-agent's output suggests a next command (e.g. "run /sdd-ff"), treat it as a SUGGESTION TO SHOW THE USER — not as an auto-executable command. Always ask the user before proceeding.
 
 **Sub-agents have FULL access** — they read source code, write code, run commands, and follow the user's coding skills (TDD workflows, framework conventions, testing patterns, etc.).
 


### PR DESCRIPTION
## Problem

When a sub-agent (e.g. `sdd-propose`, `sdd-audit`) includes a phrase like *"Ready to proceed with `/sdd-ff`"* in its output, the orchestrator tries to invoke it via the `Skill` tool. Since `sdd-ff` is not a registered skill, this causes a repeated error:

```
Unknown skill: sdd-ff
```

This was observed in real usage — also reported by users in the community who found that `/sdd-new` and `/sdd-ff` could not be found.

## Root Cause

The orchestrator has no explicit rule distinguishing **meta-commands** (composite workflows it handles itself by chaining Task tool calls) from **leaf skills** (atomic skills invocable via the Skill tool).

Without this distinction, the LLM sees a command-like string in sub-agent output and reasonably tries to invoke it as a skill.

## Fix

Added two rules to the **Orchestrator Rules** section:

**Rule 8 — Meta-commands are not skills:**
> `/sdd-ff`, `/sdd-continue`, `/sdd-new` are META-COMMANDS handled by the orchestrator itself. NEVER invoke them via the Skill tool. Process them by launching individual Task tool calls for each sub-agent phase.

**Rule 9 — Sub-agent suggestions require user approval:**
> When a sub-agent's output suggests a next command, treat it as a SUGGESTION TO SHOW THE USER — not as an auto-executable command. Always ask the user before proceeding.

## Testing

Verified by running a full `sdd-audit → /sdd-ff → /sdd-apply` sequence on a real project. With these rules applied, the orchestrator correctly presents suggestions to the user instead of attempting to invoke them.