### PR TITLE
fix: copy shared convention files to skill installations

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -142,6 +142,19 @@ function Install-Skills {
 
     New-Item -ItemType Directory -Path $TargetDir -Force | Out-Null
 
+    # Copy shared convention files (_shared/)
+    $sharedSrc = Join-Path $SkillsSrc '_shared'
+    $sharedTarget = Join-Path $TargetDir '_shared'
+
+    if (Test-Path $sharedSrc) {
+        New-Item -ItemType Directory -Path $sharedTarget -Force | Out-Null
+        $sharedFiles = Get-ChildItem -Path $sharedSrc -Filter '*.md'
+        foreach ($file in $sharedFiles) {
+            Copy-Item -Path $file.FullName -Destination $sharedTarget -Force
+        }
+        Write-Skill '_shared (convention files)'
+    }
+
     $count = 0
     $skillDirs = Get-ChildItem -Path $SkillsSrc -Directory -Filter 'sdd-*'
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -189,6 +189,18 @@ install_skills() {
 
     mkdir -p "$target_dir"
 
+    # Copy shared convention files (_shared/)
+    local shared_src="$SKILLS_SRC/_shared"
+    local shared_target="$target_dir/_shared"
+
+    if [ -d "$shared_src" ]; then
+        mkdir -p "$shared_target" 2>/dev/null || {
+            make_writable "$shared_target"
+        }
+        cp "$shared_src"/*.md "$shared_target/" 2>/dev/null || true
+        print_skill "_shared (convention files)"
+    fi
+
     local count=0
     for skill_dir in "$SKILLS_SRC"/sdd-*/; do
         local skill_name


### PR DESCRIPTION
Install scripts now copy the three required shared convention files to each tool's skill installation directory.

These files are required by all SDD sub-agents when they read and follow persistence contracts and conventions.