### PR TITLE
fix(installer): copy shared convention files to skill installations

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -142,6 +142,19 @@ function Install-Skills {
 
     New-Item -ItemType Directory -Path $TargetDir -Force | Out-Null
 
+    # Copy shared convention files (_shared/)
+    $sharedSrc = Join-Path $SkillsSrc '_shared'
+    $sharedTarget = Join-Path $TargetDir '_shared'
+
+    if (Test-Path $sharedSrc) {
+        New-Item -ItemType Directory -Path $sharedTarget -Force | Out-Null
+        $sharedFiles = Get-ChildItem -Path $sharedSrc -Filter '*.md'
+        foreach ($file in $sharedFiles) {
+            Copy-Item -Path $file.FullName -Destination $sharedTarget -Force
+        }
+        Write-Skill '_shared (convention files)'
+    }
+
     $count = 0
     $skillDirs = Get-ChildItem -Path $SkillsSrc -Directory -Filter 'sdd-*'
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -189,6 +189,18 @@ install_skills() {
 
     mkdir -p "$target_dir"
 
+    # Copy shared convention files (_shared/)
+    local shared_src="$SKILLS_SRC/_shared"
+    local shared_target="$target_dir/_shared"
+
+    if [ -d "$shared_src" ]; then
+        mkdir -p "$shared_target" 2>/dev/null || {
+            make_writable "$shared_target"
+        }
+        cp "$shared_src"/*.md "$shared_target/" 2>/dev/null || true
+        print_skill "_shared (convention files)"
+    fi
+
     local count=0
     for skill_dir in "$SKILLS_SRC"/sdd-*/; do
         local skill_name


### PR DESCRIPTION
## 📌 Summary
This PR fixes the skill installer so required shared convention files are copied during installation.

## ✅ What changed
- Updated `scripts/install.sh` to copy `_shared/*.md` into each installed skill directory.
- Updated `scripts/install.ps1` with the same behavior for Windows installs.

## 🧠 Why
SDD sub-agent skills expect these files to exist in their installation directory:
- `persistence-contract.md`
- `engram-convention.md`
- `openspec-convention.md`

Before this fix, those files were not installed, causing skills to fail when loading persistence conventions.

## 🧪 Validation
- Verified changes are present in both installer scripts.
- No runtime behavior changes outside installation flow.

## 📋 Checklist
- [x] Conventional Commit title
- [x] Scope is minimal and focused
- [x] Cross-platform installer parity (`.sh` + `.ps1`)
