### PR TITLE
Optimize artifact retrieval for runtimes without true subagents

### DIFF
--- a/examples/antigravity/sdd-orchestrator.md
+++ b/examples/antigravity/sdd-orchestrator.md
@@ -41,15 +41,14 @@ SDD is the structured planning layer for substantial changes.
 - In `none`, do not write project files. Return results inline and recommend enabling `engram` or `openspec`.
 
 ### Commands
+
 - `/sdd-init` -> run `sdd-init`
 - `/sdd-explore <topic>` -> run `sdd-explore`
-- `/sdd-new <change>` -> run `sdd-explore` then `sdd-propose`
 - `/sdd-continue [change]` -> create next missing artifact in dependency chain
-- `/sdd-ff [change]` -> run `sdd-propose` -> `sdd-spec` -> `sdd-design` -> `sdd-tasks`
 - `/sdd-apply [change]` -> run `sdd-apply` in batches
 - `/sdd-verify [change]` -> run `sdd-verify`
 - `/sdd-archive [change]` -> run `sdd-archive`
-- `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU (the orchestrator). Do NOT invoke them as skills.
+- `/sdd-continue` are meta-command handled by YOU (the orchestrator). Do NOT invoke them as skills.
 
 ### Dependency Graph
 ```

--- a/skills/sdd-apply/SKILL.md
+++ b/skills/sdd-apply/SKILL.md
@@ -24,11 +24,22 @@ From the orchestrator:
 
 Read and follow `skills/_shared/persistence-contract.md` for mode resolution rules.
 
+Artifact resolution priority (prompt-first):
+1. Prompt context from orchestrator (highest priority)
+2. Engram persistence (`mem_search` -> `mem_get_observation`)
+3. Filesystem artifacts (`openspec`)
+
+If a required artifact is already present in the prompt context, use it directly and **DO NOT** query Engram for that artifact.
+Only query Engram for missing dependencies or when prompt content is explicitly partial/truncated.
+This keeps compatibility with runtimes that pass full artifacts inline or by reference.
+
 - If mode is `engram`:
+
+  Resolve dependencies using prompt-first priority. Query Engram only for artifacts not already provided in the prompt.
 
   **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will work with incomplete specs and produce wrong code.**
 
-  **STEP A — SEARCH** (get IDs only — content is truncated):
+  **STEP A — SEARCH** (ONLY for artifacts missing from prompt; get IDs only — content is truncated):
   1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
   2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID
   3. `mem_search(query: "sdd/{change-name}/design", project: "{project}")` → save ID

--- a/skills/sdd-archive/SKILL.md
+++ b/skills/sdd-archive/SKILL.md
@@ -23,11 +23,22 @@ From the orchestrator:
 
 Read and follow `skills/_shared/persistence-contract.md` for mode resolution rules.
 
+Artifact resolution priority (prompt-first):
+1. Prompt context from orchestrator (highest priority)
+2. Engram persistence (`mem_search` -> `mem_get_observation`)
+3. Filesystem artifacts (`openspec`)
+
+If a required artifact is already present in the prompt context, use it directly and **DO NOT** query Engram for that artifact.
+Only query Engram for missing dependencies or when prompt content is explicitly partial/truncated.
+This keeps compatibility with runtimes that pass full artifacts inline or by reference.
+
 - If mode is `engram`:
+
+  Resolve dependencies using prompt-first priority. Query Engram only for artifacts not already provided in the prompt.
 
   **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will archive with incomplete data.**
 
-  **STEP A — SEARCH** (get IDs only — content is truncated):
+  **STEP A — SEARCH** (ONLY for artifacts missing from prompt; get IDs only — content is truncated):
   1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
   2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID
   3. `mem_search(query: "sdd/{change-name}/design", project: "{project}")` → save ID

--- a/skills/sdd-design/SKILL.md
+++ b/skills/sdd-design/SKILL.md
@@ -23,11 +23,22 @@ From the orchestrator:
 
 Read and follow `skills/_shared/persistence-contract.md` for mode resolution rules.
 
+Artifact resolution priority (prompt-first):
+1. Prompt context from orchestrator (highest priority)
+2. Engram persistence (`mem_search` -> `mem_get_observation`)
+3. Filesystem artifacts (`openspec`)
+
+If a required artifact is already present in the prompt context, use it directly and **DO NOT** query Engram for that artifact.
+Only query Engram for missing dependencies or when prompt content is explicitly partial/truncated.
+This keeps compatibility with runtimes that pass full artifacts inline or by reference.
+
 - If mode is `engram`:
+
+  Resolve dependencies using prompt-first priority. Query Engram only for artifacts not already provided in the prompt.
 
   **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will work with incomplete data and produce wrong design.**
 
-  **STEP A — SEARCH** (get IDs only — content is truncated):
+  **STEP A — SEARCH** (ONLY for artifacts missing from prompt; get IDs only — content is truncated):
   1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
   2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID (optional — may not exist if running in parallel with sdd-spec)
 

--- a/skills/sdd-explore/SKILL.md
+++ b/skills/sdd-explore/SKILL.md
@@ -23,7 +23,18 @@ The orchestrator will give you:
 
 Read and follow `skills/_shared/persistence-contract.md` for mode resolution rules.
 
+Artifact resolution priority (prompt-first):
+1. Prompt context from orchestrator (highest priority)
+2. Engram persistence (`mem_search` -> `mem_get_observation`)
+3. Filesystem artifacts (`openspec`)
+
+If a required artifact is already present in the prompt context, use it directly and **DO NOT** query Engram for that artifact.
+Only query Engram for missing dependencies or when prompt content is explicitly partial/truncated.
+This keeps compatibility with runtimes that pass full artifacts inline or by reference.
+
 - If mode is `engram`:
+
+  Resolve dependencies using prompt-first priority. Query Engram only for artifacts not already provided in the prompt.
 
   **Read context** (optional — load project context if available):
   1. `mem_search(query: "sdd-init/{project}", project: "{project}")` → get observation ID
@@ -60,14 +71,15 @@ Read and follow `skills/_shared/persistence-contract.md` for mode resolution rul
 
 ### Retrieving Context
 
-Before starting, load any existing project context and specs per the active convention:
-- **engram**:
+Before starting, resolve context with prompt-first priority:
+- **prompt context first**: if the orchestrator already included project context/artifacts, use that directly.
+- **engram**: only if required context is missing from prompt:
   1. `mem_search(query: "sdd-init/{project}", project: "{project}")` → get observation ID
   2. `mem_get_observation(id: {id from step 1})` → full project context
   3. Optionally `mem_search(query: "sdd/", project: "{project}")` → find existing artifacts
   (If no results, proceed without prior context.)
-- **openspec**: Read `openspec/config.yaml` and `openspec/specs/`.
-- **none**: Use whatever context the orchestrator passed in the prompt.
+- **openspec**: if still missing, read `openspec/config.yaml` and `openspec/specs/`.
+- **none**: use whatever context the orchestrator passed in the prompt.
 
 ## What to Do
 

--- a/skills/sdd-propose/SKILL.md
+++ b/skills/sdd-propose/SKILL.md
@@ -24,9 +24,20 @@ From the orchestrator:
 
 Read and follow `skills/_shared/persistence-contract.md` for mode resolution rules.
 
+Artifact resolution priority (prompt-first):
+1. Prompt context from orchestrator (highest priority)
+2. Engram persistence (`mem_search` -> `mem_get_observation`)
+3. Filesystem artifacts (`openspec`)
+
+If a required artifact is already present in the prompt context, use it directly and **DO NOT** query Engram for that artifact.
+Only query Engram for missing dependencies or when prompt content is explicitly partial/truncated.
+This keeps compatibility with runtimes that pass full artifacts inline or by reference.
+
 - If mode is `engram`:
 
-  **Read dependencies** (two-step — search returns truncated previews):
+  Resolve dependencies using prompt-first priority. Query Engram only for artifacts not already provided in the prompt.
+
+  **Read dependencies** (prompt-first: only use two-step retrieval for artifacts missing from prompt; search returns truncated previews):
   1. `mem_search(query: "sdd/{change-name}/explore", project: "{project}")` → get observation ID (optional — may not exist)
   2. If found: `mem_get_observation(id: {id})` → full exploration content
   3. `mem_search(query: "sdd-init/{project}", project: "{project}")` → project context (optional)

--- a/skills/sdd-spec/SKILL.md
+++ b/skills/sdd-spec/SKILL.md
@@ -23,11 +23,22 @@ From the orchestrator:
 
 Read and follow `skills/_shared/persistence-contract.md` for mode resolution rules.
 
+Artifact resolution priority (prompt-first):
+1. Prompt context from orchestrator (highest priority)
+2. Engram persistence (`mem_search` -> `mem_get_observation`)
+3. Filesystem artifacts (`openspec`)
+
+If a required artifact is already present in the prompt context, use it directly and **DO NOT** query Engram for that artifact.
+Only query Engram for missing dependencies or when prompt content is explicitly partial/truncated.
+This keeps compatibility with runtimes that pass full artifacts inline or by reference.
+
 - If mode is `engram`:
+
+  Resolve dependencies using prompt-first priority. Query Engram only for artifacts not already provided in the prompt.
 
   **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will work with incomplete data and produce wrong specs.**
 
-  **STEP A — SEARCH** (get IDs only — content is truncated):
+  **STEP A — SEARCH** (ONLY for artifacts missing from prompt; get IDs only — content is truncated):
   1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
 
   **STEP B — RETRIEVE FULL CONTENT** (mandatory):

--- a/skills/sdd-tasks/SKILL.md
+++ b/skills/sdd-tasks/SKILL.md
@@ -23,11 +23,22 @@ From the orchestrator:
 
 Read and follow `skills/_shared/persistence-contract.md` for mode resolution rules.
 
+Artifact resolution priority (prompt-first):
+1. Prompt context from orchestrator (highest priority)
+2. Engram persistence (`mem_search` -> `mem_get_observation`)
+3. Filesystem artifacts (`openspec`)
+
+If a required artifact is already present in the prompt context, use it directly and **DO NOT** query Engram for that artifact.
+Only query Engram for missing dependencies or when prompt content is explicitly partial/truncated.
+This keeps compatibility with runtimes that pass full artifacts inline or by reference.
+
 - If mode is `engram`:
+
+  Resolve dependencies using prompt-first priority. Query Engram only for artifacts not already provided in the prompt.
 
   **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will work with incomplete data and produce wrong tasks.**
 
-  **STEP A — SEARCH** (get IDs only — content is truncated):
+  **STEP A — SEARCH** (ONLY for artifacts missing from prompt; get IDs only — content is truncated):
   1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
   2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID
   3. `mem_search(query: "sdd/{change-name}/design", project: "{project}")` → save ID

--- a/skills/sdd-verify/SKILL.md
+++ b/skills/sdd-verify/SKILL.md
@@ -25,11 +25,22 @@ From the orchestrator:
 
 Read and follow `skills/_shared/persistence-contract.md` for mode resolution rules.
 
+Artifact resolution priority (prompt-first):
+1. Prompt context from orchestrator (highest priority)
+2. Engram persistence (`mem_search` -> `mem_get_observation`)
+3. Filesystem artifacts (`openspec`)
+
+If a required artifact is already present in the prompt context, use it directly and **DO NOT** query Engram for that artifact.
+Only query Engram for missing dependencies or when prompt content is explicitly partial/truncated.
+This keeps compatibility with runtimes that pass full artifacts inline or by reference.
+
 - If mode is `engram`:
+
+  Resolve dependencies using prompt-first priority. Query Engram only for artifacts not already provided in the prompt.
 
   **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will verify against incomplete specs and miss issues.**
 
-  **STEP A — SEARCH** (get IDs only — content is truncated):
+  **STEP A — SEARCH** (ONLY for artifacts missing from prompt; get IDs only — content is truncated):
   1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
   2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID
   3. `mem_search(query: "sdd/{change-name}/design", project: "{project}")` → save ID


### PR DESCRIPTION
##Description

This PR introduces a prompt-first artifact resolution strategy.

Artifacts are now resolved in the following order:

1. prompt context
2. engram persistence
3. filesystem artifacts (openspec)

This avoids unnecessary Engram reads in runtimes where
phases execute in the same context (e.g. Antigravity),
while remaining fully compatible with subagent-based runtimes.