### PR TITLE
fix(scripts): iterate all skill dirs instead of hardcoded glob

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -193,12 +193,13 @@ install_skills() {
         ok "_shared conventions"
     fi
 
-    # Copy sdd-* + skill-registry + issue-creation + branch-pr
+    # Copy all skills (any subdirectory with a SKILL.md, except _shared)
     local count=0
-    for skill_dir in "$SKILLS_SRC"/sdd-*/ "$SKILLS_SRC"/skill-registry/ "$SKILLS_SRC"/issue-creation/ "$SKILLS_SRC"/branch-pr/; do
+    for skill_dir in "$SKILLS_SRC"/*/; do
         [ -d "$skill_dir" ] || continue
         local skill_name
         skill_name=$(basename "$skill_dir")
+        [ "$skill_name" = "_shared" ] && continue
         [ -f "$skill_dir/SKILL.md" ] || continue
 
         mkdir -p "$target_dir/$skill_name"


### PR DESCRIPTION
## Summary

- **Reemplaza el glob hardcodeado** (`sdd-*/ skill-registry/`) en `install_skills()` por una iteración dinámica sobre todos los subdirectorios de `skills/` que contengan un `SKILL.md`
- **Excluye `_shared/`** que ya se maneja por separado antes del loop
- **Previene futuros incidentes**: cualquier skill nuevo será instalado automáticamente sin necesidad de modificar el script

### Contexto

El glob hardcodeado ya causó dos incidentes:
- #30 — `skill-registry` no se copiaba
- #41 — `issue-creation` y `branch-pr` no se copiaban

En lugar de seguir agregando entradas al glob manualmente, esta PR elimina el patrón por completo.

Closes #41

## Test plan

- [ ] Ejecutar `./scripts/setup.sh --all` y verificar que **todos** los skills se copian (incluyendo `issue-creation` y `branch-pr`)
- [ ] Verificar que `_shared/` NO se duplica (ya se copia antes del loop)
- [ ] Agregar un directorio dummy `skills/test-skill/SKILL.md` y confirmar que se instala sin modificar el script
- [ ] Verificar que directorios sin `SKILL.md` se ignoran correctamente