### PR TITLE
fix(skills): add SKILL.md files for sdd-new, sdd-ff, sdd-continue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ When working on this project, load the relevant skill(s) BEFORE writing any code
 | Skill | Trigger | Path |
 |-------|---------|------|
 | `sdd-init` | When initializing SDD in a project, or user says "sdd init". | [`skills/sdd-init/SKILL.md`](skills/sdd-init/SKILL.md) |
+| `sdd-new` | When starting a new SDD change — runs exploration then creates a proposal. | [`skills/sdd-new/SKILL.md`](skills/sdd-new/SKILL.md) |
+| `sdd-continue` | When continuing the next SDD phase in the dependency chain for an active change. | [`skills/sdd-continue/SKILL.md`](skills/sdd-continue/SKILL.md) |
+| `sdd-ff` | When fast-forwarding all SDD planning phases — proposal through tasks. | [`skills/sdd-ff/SKILL.md`](skills/sdd-ff/SKILL.md) |
 | `sdd-explore` | When thinking through a feature, investigating the codebase, or clarifying requirements. | [`skills/sdd-explore/SKILL.md`](skills/sdd-explore/SKILL.md) |
 | `sdd-propose` | When creating or updating a change proposal with intent, scope, and approach. | [`skills/sdd-propose/SKILL.md`](skills/sdd-propose/SKILL.md) |
 | `sdd-spec` | When writing or updating specifications with requirements and scenarios. | [`skills/sdd-spec/SKILL.md`](skills/sdd-spec/SKILL.md) |

--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -59,13 +59,12 @@ SDD is the structured planning layer for substantial changes.
 ### Commands
 - `/sdd-init` -> run `sdd-init`
 - `/sdd-explore <topic>` -> run `sdd-explore`
-- `/sdd-new <change>` -> run `sdd-explore` then `sdd-propose`
-- `/sdd-continue [change]` -> create next missing artifact in dependency chain
-- `/sdd-ff [change]` -> run `sdd-propose` -> `sdd-spec` -> `sdd-design` -> `sdd-tasks`
+- `/sdd-new <change>` -> run `sdd-new` (orchestrates explore then propose)
+- `/sdd-continue [change]` -> run `sdd-continue` (determines and runs next phase)
+- `/sdd-ff [change]` -> run `sdd-ff` (orchestrates propose -> spec -> design -> tasks)
 - `/sdd-apply [change]` -> run `sdd-apply` in batches
 - `/sdd-verify [change]` -> run `sdd-verify`
 - `/sdd-archive [change]` -> run `sdd-archive`
-- `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU (the orchestrator). Do NOT invoke them as skills.
 
 ### Dependency Graph
 ```

--- a/skills/sdd-continue/SKILL.md
+++ b/skills/sdd-continue/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: sdd-continue
+description: >
+  Continue the next SDD phase in the dependency chain for an active change.
+  Trigger: When the user says "sdd continue", "continuar", or wants to advance to the next planning phase.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## Purpose
+
+You are an ORCHESTRATOR for continuing an active SDD change. You determine which artifacts already exist, identify the next phase in the dependency chain, and delegate that phase to a sub-agent. You do NOT execute phase work inline.
+
+## What You Receive
+
+- Change name (e.g., "add-dark-mode") — may be omitted if only one active change exists
+- Artifact store mode (`engram | openspec | hybrid | none`)
+- Working directory and project name
+
+## Dependency Graph
+
+```
+proposal -> specs --> tasks -> apply -> verify -> archive
+             ^
+             |
+           design
+```
+
+- `specs` and `design` both depend on `proposal`
+- `tasks` depends on BOTH `specs` and `design`
+- `apply` depends on `tasks`
+- `verify` depends on `apply`
+- `archive` depends on `verify`
+
+## Workflow
+
+### Step 1: Discover Existing Artifacts
+
+Check which artifacts already exist for this change.
+
+**If mode is `engram`:**
+```
+mem_search(query: "sdd/{change-name}/", project: "{project}")
+```
+Parse the results to identify which artifact types exist (explore, proposal, spec, design, tasks, apply-progress, verify-report, archive-report).
+
+**If mode is `openspec` or `hybrid`:**
+Check for files in `openspec/changes/{change-name}/`:
+- `exploration.md` → explore exists
+- `proposal.md` → proposal exists
+- `spec.md` → spec exists
+- `design.md` → design exists
+- `tasks.md` → tasks exists
+
+**If mode is `none`:**
+Report that state was not persisted and ask the user which phase to run next.
+
+### Step 2: Determine Next Phase
+
+Based on what exists, determine the next phase:
+
+| Exists | Missing | Next Phase |
+|--------|---------|------------|
+| nothing | proposal | `sdd-propose` |
+| proposal | specs, design | `sdd-spec` + `sdd-design` (parallel) |
+| proposal, specs | design | `sdd-design` |
+| proposal, design | specs | `sdd-spec` |
+| proposal, specs, design | tasks | `sdd-tasks` |
+| all planning | apply | `sdd-apply` |
+| apply done | verify | `sdd-verify` |
+| verify done | archive | `sdd-archive` |
+| all done | — | Report: change is complete |
+
+### Step 3: Launch Next Phase
+
+Launch the appropriate sub-agent(s) via Task tool. Use the same launch pattern as other SDD orchestrator skills:
+
+```
+Task(
+  description: 'sdd-{phase} for {change-name}',
+  prompt: 'You are an SDD sub-agent. Read the skill file at skills/sdd-{phase}/SKILL.md FIRST, then follow its instructions exactly.
+
+  CONTEXT:
+  - Project: {project path}
+  - Change: {change-name}
+  - Artifact store mode: {engram|openspec|hybrid|none}
+  - Previous artifacts: {list of existing artifact references}
+
+  TASK:
+  {Phase-specific task description}
+
+  Return structured output with: status, executive_summary, artifacts, next_recommended, risks.'
+)
+```
+
+If both `sdd-spec` and `sdd-design` are needed, launch them in PARALLEL.
+
+### Step 4: Present Results
+
+After the sub-agent(s) complete:
+
+```markdown
+## Continue: {change-name}
+
+### Phase Completed
+{phase name} — {status}
+
+### Summary
+{executive summary from sub-agent}
+
+### Artifact State
+| Artifact | Status |
+|----------|--------|
+| Proposal | {done/missing} |
+| Spec | {done/missing} |
+| Design | {done/missing} |
+| Tasks | {done/missing} |
+| Apply | {done/missing} |
+| Verify | {done/missing} |
+| Archive | {done/missing} |
+
+### Next Step
+{next recommended phase, or "all planning complete — ready for /sdd-apply"}
+```
+
+## Rules
+
+- NEVER execute phase work inline — always delegate to sub-agents
+- ALWAYS check existing artifacts before deciding the next phase
+- If specs and design are both missing, launch them in PARALLEL
+- If mode is `none`, ask the user which phase to run (state is not persisted)
+- Pass artifact references to sub-agents, NOT content
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)

--- a/skills/sdd-ff/SKILL.md
+++ b/skills/sdd-ff/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: sdd-ff
+description: >
+  Fast-forward all SDD planning phases — proposal through tasks.
+  Trigger: When the user says "sdd ff <name>", "fast forward", or wants to run all planning phases in sequence.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## Purpose
+
+You are an ORCHESTRATOR for fast-forwarding all SDD planning phases. You coordinate four phases in sequence — propose, spec, design, tasks — by delegating to sub-agents. You do NOT execute phase work inline.
+
+## What You Receive
+
+- Change name (e.g., "add-dark-mode")
+- Artifact store mode (`engram | openspec | hybrid | none`)
+- Working directory and project name
+
+## Workflow
+
+Run these sub-agents in sequence. Do NOT show intermediate results — present a combined summary after ALL phases complete.
+
+### Step 1: Launch Proposal
+
+Launch a sub-agent for `sdd-propose`:
+
+```
+Task(
+  description: 'sdd-propose for {change-name}',
+  prompt: 'You are an SDD sub-agent. Read the skill file at skills/sdd-propose/SKILL.md FIRST, then follow its instructions exactly.
+
+  CONTEXT:
+  - Project: {project path}
+  - Change: {change-name}
+  - Artifact store mode: {engram|openspec|hybrid|none}
+
+  TASK:
+  Create a proposal for the change "{change-name}".
+
+  Return structured output with: status, executive_summary, artifacts, next_recommended, risks.'
+)
+```
+
+If status is `blocked`, stop and report to user.
+
+### Step 2: Launch Spec and Design (parallel)
+
+After proposal completes successfully, launch BOTH in parallel:
+
+**Spec sub-agent:**
+```
+Task(
+  description: 'sdd-spec for {change-name}',
+  prompt: 'You are an SDD sub-agent. Read the skill file at skills/sdd-spec/SKILL.md FIRST, then follow its instructions exactly.
+
+  CONTEXT:
+  - Project: {project path}
+  - Change: {change-name}
+  - Artifact store mode: {engram|openspec|hybrid|none}
+  - Previous artifacts: proposal at sdd/{change-name}/proposal
+
+  TASK:
+  Write specifications for the change "{change-name}" based on the proposal.
+
+  Return structured output with: status, executive_summary, artifacts, next_recommended, risks.'
+)
+```
+
+**Design sub-agent:**
+```
+Task(
+  description: 'sdd-design for {change-name}',
+  prompt: 'You are an SDD sub-agent. Read the skill file at skills/sdd-design/SKILL.md FIRST, then follow its instructions exactly.
+
+  CONTEXT:
+  - Project: {project path}
+  - Change: {change-name}
+  - Artifact store mode: {engram|openspec|hybrid|none}
+  - Previous artifacts: proposal at sdd/{change-name}/proposal
+
+  TASK:
+  Create the technical design for the change "{change-name}" based on the proposal.
+
+  Return structured output with: status, executive_summary, artifacts, next_recommended, risks.'
+)
+```
+
+If either returns `blocked`, stop and report to user.
+
+### Step 3: Launch Tasks
+
+After BOTH spec and design complete successfully:
+
+```
+Task(
+  description: 'sdd-tasks for {change-name}',
+  prompt: 'You are an SDD sub-agent. Read the skill file at skills/sdd-tasks/SKILL.md FIRST, then follow its instructions exactly.
+
+  CONTEXT:
+  - Project: {project path}
+  - Change: {change-name}
+  - Artifact store mode: {engram|openspec|hybrid|none}
+  - Previous artifacts: proposal at sdd/{change-name}/proposal, spec at sdd/{change-name}/spec, design at sdd/{change-name}/design
+
+  TASK:
+  Break down the change "{change-name}" into implementation tasks based on the spec and design.
+
+  Return structured output with: status, executive_summary, artifacts, next_recommended, risks.'
+)
+```
+
+### Step 4: Present Combined Summary
+
+After ALL four phases complete, present a single summary:
+
+```markdown
+## Fast-Forward Complete: {change-name}
+
+| Phase | Status | Summary |
+|-------|--------|---------|
+| Proposal | {status} | {one-line} |
+| Spec | {status} | {one-line} |
+| Design | {status} | {one-line} |
+| Tasks | {status} | {one-line} |
+
+### Artifacts Created
+- {list all artifact keys/paths}
+
+### Next Steps
+Ready for implementation. Run `/sdd-apply {change-name}` to start coding.
+
+### Risks
+- {aggregated risks from all phases}
+```
+
+## Rules
+
+- NEVER execute phase work inline — always delegate to sub-agents
+- Run spec and design in PARALLEL (they both depend only on proposal)
+- Tasks depends on BOTH spec and design — wait for both before launching
+- Present ONE combined summary at the end, not between each phase
+- If any phase returns `blocked`, stop the entire fast-forward and report
+- Pass artifact references to sub-agents, NOT content
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)

--- a/skills/sdd-new/SKILL.md
+++ b/skills/sdd-new/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: sdd-new
+description: >
+  Start a new SDD change — runs exploration then creates a proposal.
+  Trigger: When the user says "sdd new <name>", "nuevo cambio", "new change", or the orchestrator launches a new change workflow.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## Purpose
+
+You are an ORCHESTRATOR for starting a new SDD change. You coordinate two phases in sequence — exploration and proposal — by delegating to sub-agents. You do NOT execute phase work inline.
+
+## What You Receive
+
+- Change name (e.g., "add-dark-mode")
+- Artifact store mode (`engram | openspec | hybrid | none`)
+- Working directory and project name
+
+## Workflow
+
+### Step 1: Launch Exploration
+
+Launch a sub-agent to run the `sdd-explore` phase:
+
+```
+Task(
+  description: 'sdd-explore for {change-name}',
+  prompt: 'You are an SDD sub-agent. Read the skill file at skills/sdd-explore/SKILL.md FIRST, then follow its instructions exactly.
+
+  CONTEXT:
+  - Project: {project path}
+  - Change: {change-name}
+  - Artifact store mode: {engram|openspec|hybrid|none}
+
+  TASK:
+  Explore the codebase for the change "{change-name}". Investigate affected areas, compare approaches, and return a structured analysis.
+
+  Return structured output with: status, executive_summary, artifacts, next_recommended, risks.'
+)
+```
+
+### Step 2: Present Exploration Results
+
+After the exploration sub-agent completes:
+1. Show the user the executive summary
+2. Show key findings (affected areas, recommended approach, risks)
+3. Ask: "Exploration complete. Shall I proceed to create the proposal?"
+
+### Step 3: Launch Proposal
+
+If the user approves, launch a sub-agent to run the `sdd-propose` phase:
+
+```
+Task(
+  description: 'sdd-propose for {change-name}',
+  prompt: 'You are an SDD sub-agent. Read the skill file at skills/sdd-propose/SKILL.md FIRST, then follow its instructions exactly.
+
+  CONTEXT:
+  - Project: {project path}
+  - Change: {change-name}
+  - Artifact store mode: {engram|openspec|hybrid|none}
+  - Previous artifacts: exploration at sdd/{change-name}/explore
+
+  TASK:
+  Create a proposal for the change "{change-name}" based on the exploration results.
+
+  Return structured output with: status, executive_summary, artifacts, next_recommended, risks.'
+)
+```
+
+### Step 4: Present Proposal Summary
+
+After the proposal sub-agent completes:
+1. Show the user the proposal summary (intent, scope, approach, risk level)
+2. Suggest next steps: "Proposal created. You can continue with `/sdd-continue {change-name}` for specs and design, or `/sdd-ff {change-name}` to fast-forward all planning phases."
+
+## Rules
+
+- NEVER execute exploration or proposal work inline — always delegate to sub-agents
+- ALWAYS show exploration results to the user before proceeding to proposal
+- ALWAYS ask for user approval between exploration and proposal
+- If exploration returns `status: blocked`, show the blocker and stop
+- Pass artifact references (topic keys or file paths) to sub-agents, NOT content
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)


### PR DESCRIPTION
Closes #49

## PR Type
- [x] Bug fix

## Summary

- Add missing `SKILL.md` files for `/sdd-new`, `/sdd-ff`, and `/sdd-continue` so they work as slash commands in Claude Code
- These only existed as OpenCode command files — Claude Code requires a registered skill to invoke any `/command`
- Update `AGENTS.md` index and `examples/claude-code/CLAUDE.md` orchestrator instructions

## Changes

| File | Change |
|------|--------|
| `skills/sdd-new/SKILL.md` | New — orchestrates explore → propose |
| `skills/sdd-ff/SKILL.md` | New — orchestrates propose → spec → design → tasks |
| `skills/sdd-continue/SKILL.md` | New — determines next phase in dependency chain |
| `AGENTS.md` | Add three new skills to the index |
| `examples/claude-code/CLAUDE.md` | Remove "meta-commands not skills" instruction |

## Test Plan

- [x] Skills load correctly in Claude Code (`~/.claude/skills/`)
- [x] `/sdd-new` appears in Claude Code's available skills list
- [x] `/sdd-ff` appears in Claude Code's available skills list
- [x] `/sdd-continue` appears in Claude Code's available skills list
- [x] Manually tested skill registration in Claude Code session

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label (pending)
- [x] Skills tested in Claude Code
- [x] Docs updated (AGENTS.md)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers