### PR TITLE
docs(claude-code): aclarar skills vs meta-commands en sección Commands

### DIFF
--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -71,15 +71,20 @@ SDD is the structured planning layer for substantial changes.
 | `none` | Return results inline only. Recommend enabling engram or openspec. |
 
 ### Commands
+
+#### Single-phase skills (invoke via Skill tool)
 - `/sdd-init` -> run `sdd-init`
 - `/sdd-explore <topic>` -> run `sdd-explore`
-- `/sdd-new <change>` -> run `sdd-explore` then `sdd-propose`
-- `/sdd-continue [change]` -> create next missing artifact in dependency chain
-- `/sdd-ff [change]` -> run `sdd-propose` -> `sdd-spec` -> `sdd-design` -> `sdd-tasks`
 - `/sdd-apply [change]` -> run `sdd-apply` in batches
 - `/sdd-verify [change]` -> run `sdd-verify`
 - `/sdd-archive [change]` -> run `sdd-archive`
-- `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU (the orchestrator). Do NOT invoke them as skills.
+
+#### Meta-commands (type as text — orchestrator handles directly, NOT skills)
+- `sdd-new <change>` -> orchestrate `sdd-explore` then `sdd-propose` via Task tool
+- `sdd-continue [change]` -> determine next missing artifact and launch it via Task tool
+- `sdd-ff [change]` -> orchestrate `sdd-propose` -> `sdd-spec` -> `sdd-design` -> `sdd-tasks` via Task tool
+
+> **Note:** Meta-commands are composite workflows. The orchestrator processes them by launching sub-agents for each phase — never by invoking the Skill tool. In Claude Code, `/` triggers the Skill tool, so these must be typed as plain text (e.g. `sdd-new my-feature`). If a sub-agent suggests "run /sdd-ff", show it to the user as a suggestion, do not auto-execute.
 
 ### Dependency Graph
 ```


### PR DESCRIPTION
Closes #51

## Tipo de PR
- [x] Solo documentación

## Resumen

- Separa la sección "Commands" de `examples/claude-code/CLAUDE.md` en dos subsecciones claras:
  - **Single-phase skills**: invocables con `/` via Skill tool (`/sdd-init`, `/sdd-explore`, etc.)
  - **Meta-commands**: se escriben como texto plano (`sdd-new`, `sdd-continue`, `sdd-ff`) — el orchestrator los maneja directamente via Task tool
- Agrega una nota explicando por qué la distinción importa en Claude Code (donde `/` dispara el Skill tool)

## Cambios

| Archivo | Cambio |
|---------|--------|
| `examples/claude-code/CLAUDE.md` | Separar Commands en skills vs meta-commands, agregar nota explicativa |

## Contexto

Investigamos el historial del repo (commit `8f32141`, issue #8 por josemr22) y confirmamos que el diseño de meta-commands es intencional. Este PR solo mejora la documentación para que sea clara para usuarios de Claude Code.

## Test Plan

- [x] La doc refleja correctamente el comportamiento actual del orchestrator
- [x] Consistente con la regla del commit `8f32141` (meta-commands != skills)
- [x] No modifica ningún skill ni comportamiento

## Checklist

- [x] Issue aprobado linkeado
- [x] Un solo label `type:*` (pendiente)
- [x] Formato de conventional commits
- [x] Sin trailers `Co-Authored-By`